### PR TITLE
ci: use npm script

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: Node.js CI
 
 on: [push]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: npm run semantic-release


### PR DESCRIPTION
This PR makes two minor changes:
1. Rename and change the `name` key of the CI workflow file to reflect what that workflow is *doing* (opposed to the language that is is *using*)
2. Make the Release Workflow use the `semantic-release` script in `package.json`.  Otherwise we could remove that line.  I think it's best to make use of this though, that way if we want to customize this command we're setup to do so.